### PR TITLE
Refactor build script

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -127,7 +127,7 @@ function startServer () {
               // This might be useful if you copy over a binary file,
               // SVG, image, or whatever. You could make this only
               // reload on certain file types instead...
-              app.reload();
+              if (!/\.css$/i.test(ext)) app.reload();
             });
           });
         }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "description": "WebVR Rocks: Your guide to Virtual Reality in the browser.",
   "main": "dev.js",
   "scripts": {
-    "start": "npm run dev",
-    "dev": "node ./dev.js",
+    "start": "node dev.js",
     "test": "npm run prod",
-    "build": "cross-env NODE_ENV=production node ./dev.js",
+    "build": "cross-env NODE_ENV=production node dev.js",
     "deploy": "surge _prod -d https://webvr.rocks",
     "deploy:staging": "surge _prod -d https://webvrrocks.surge.sh",
     "open": "opn 'https://webvr.rocks'",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "main": "dev.js",
   "scripts": {
     "start": "npm run dev",
-    "dev": "node ./dev.js public/media/js/main.js:_prod/media/js/main.js --port 3000 --dir _prod --live --watch-glob='**/*.{html,css,svg,json}' --cors --verbose",
+    "dev": "node ./dev.js",
     "test": "npm run prod",
-    "build": "shx cp -R public _prod && node ./node_modules/.bin/nunjucks '**/*.html' --path public --unsafe --extensions $PWD/nunjucks-helpers.js --out _prod",
+    "build": "cross-env NODE_ENV=production node ./dev.js",
     "deploy": "surge _prod -d https://webvr.rocks",
     "deploy:staging": "surge _prod -d https://webvrrocks.surge.sh",
     "open": "opn 'https://webvr.rocks'",
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "budo": "github:mattdesl/budo#feature/livereload-rework",
+    "fs-extra": "^2.0.0",
     "nunjucks-cli": "github:cvan/nunjucks-cli#214cea4",
     "nunjucks-includeData": "0.0.9",
     "shelljs": "^0.7.6",
@@ -27,7 +28,10 @@
     "yonder": "^0.2.0"
   },
   "devDependencies": {
-    "opn": "^4.0.2"
+    "browserify": "^14.0.0",
+    "cross-env": "^3.1.4",
+    "opn": "^4.0.2",
+    "uglify-js": "^2.7.5"
   },
   "engines": {
     "node": "6.9.1"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "predeploy": "npm run build"
   },
   "dependencies": {
-    "budo": "github:mattdesl/budo#feature/livereload-rework",
-    "fs-extra": "^2.0.0",
     "nunjucks-cli": "github:cvan/nunjucks-cli#214cea4",
     "nunjucks-includeData": "0.0.9",
     "shelljs": "^0.7.6",
@@ -27,6 +25,8 @@
     "yonder": "^0.2.0"
   },
   "devDependencies": {
+    "budo": "github:mattdesl/budo#feature/livereload-rework",
+    "fs-extra": "^2.0.0",
     "browserify": "^14.0.0",
     "cross-env": "^3.1.4",
     "opn": "^4.0.2",


### PR DESCRIPTION
Ok, admittedly this is a beastly build script, but it's working pretty well now. I'm sure you can see why people choose Webpack/React et al to normalize some of the work, although it has its own set of complications. :smile: 

Here's some of the changes:

- Use regular budo API instead of `cli()` and simplify npm run scripts
- Don't pass `{ live: true }` instead we will just manually set it all up to our needs
- Use the `dir` flag to serve up the release directory
- Use browserify (the main reason budo would be useful) so we can take advantage of things like `require('url')` in the `public/js/main.js`
- Use the same build script for the "production" release (clean, copy files, generate templates, browserify + uglify)
- Only watch a subset of files in our input/output directories for performance
- Use `fs-extra` instead of shell calls and make sure things happen properly in sync

Using the nunjucks API instead of shell commands might improve the rendering time, though I've never used nunjucks before. Maybe check out [nunjucksify](https://github.com/rotundasoftware/nunjucksify) for reference there.