### PR TITLE
Update firefox.html with new instructions

### DIFF
--- a/public/firefox.html
+++ b/public/firefox.html
@@ -4,9 +4,6 @@
 {% block instructions %}
   <ol class="bullets-light">
     <li><span>Download and launch <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly">Firefox Nightly</a>.</span></li>
-    <li data-headset="htc_vive"><span><a href="https://github.com/ValveSoftware/openvr/raw/v1.0.6/bin/win64/openvr_api.dll">Download version 1.0.6 (64-bit) of the <strong><code>openvr_api.dll</code></strong> file</a> from the <a href="https://github.com/ValveSoftware/openvr/tree/v1.0.6">OpenVR GitHub repository</a>.</span></li>
-    <li data-headset="htc_vive"><span>Save the <code>openvr_api.dll</code> file somewhere on your computer where the user running Firefox can read it (e.g., <code>c:\openvr\</code>).</span></li>
-    <li data-headset="htc_vive"><span>In Firefox Nightly, navigate to <code>about:config</code>; change the value of <code>dom.vr.openvr.enabled</code> to <code>true</code> and <code>gfx.vr.openvr-runtime</code> to the full path of the <code>openvr_api.dll</code> file (e.g., <code>c:\openvr\openvr_api.dll</code>).</span></li>
     <li data-headset="oculus_rift"><span>Ensure that your Oculus Home settings allow for <a href="https://blog.mozvr.com/oculus-home-rift-cv1-webvr/#enablingunknownsources">Unknown Sources</a>.</span></li>
     <li><span>For PCs (especially laptops) using Nvidia chipsets, there are several methods of <a href="https://alteredqualia.com/texts/optimus/">enabling the discrete GPU</a>. One way is from the <a href="https://www.nvidia.com/Download/Find.aspx">NVIDIA Control Panel</a>: Load <code>3D Settings</code> <code>&gt;</code> <code>Manage 3D Settings</code> <code>&gt;</code> <code>Program Settings</code> tab, and select <strong>Mozilla Firefox (firefox.exe)</strong> (with the blue Nightly icon) as the program to customize, and select <strong>&ldquo;High-performance NVIDIA processor"</strong> as the preferred graphics processor.</span></li>
     <li><span>Restart Firefox Nightly.</span></li>


### PR DESCRIPTION
As of April 13th the removed steps are no longer necessary for webvr support in firefox nightly. I'm unsure if the 3rd party sources for oculus are still necessary as I don't have an oculus to test with. 

For reference the tweet about this change:
https://twitter.com/kearwoodgilbert/status/852776579750952961